### PR TITLE
fixed fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: blueprint
-Version: 0.4.0
+Version: 0.5.0
 Title: create models easily
 Description: Design model specifications from a simple, consistent API.
 Authors@R: c(

--- a/R/block.R
+++ b/R/block.R
@@ -1,6 +1,6 @@
 #' block matrix
 #' @param ... elements to coerce into a block matrix
-#' @param fix whether the values should be fixed
+#' @param fixed whether the values should be fixed
 #' @param param_names parameters associated with the elements of the matrix
 #' @param correlation whether to create as a correlation matrix
 #' @param comment comment to append
@@ -9,14 +9,14 @@
 #' # can also set as correlation matrix
 #' block(0.04, 0.61, 0.09, param_names = c("CL", "V"), correlation = TRUE)
 #' @export
-block <- function(..., param_names, fix = FALSE, correlation = FALSE, comment = NULL) {
+block <- function(..., param_names, fixed = FALSE, correlation = FALSE, comment = NULL) {
   output_matrix <- mrgsolve::bmat(..., correlation = correlation)
   output <- list(block = TRUE,
               params = param_names,
-              fix = fix,
+              fixed = fixed,
               correlation = correlation,
               matrix = output_matrix,
-              value = stringify_matrix(output_matrix, fix),
+              value = stringify_matrix(output_matrix, fixed),
               num_params = length(param_names),
               comment = comment
               )
@@ -37,14 +37,14 @@ names.block <- function(x, ...) {
 #' diagonal values
 #' @param value value
 #' @param link link parameter name
-#' @param fix whether fixed DEFAULT: FALSE
+#' @param fixed whether fixed DEFAULT: FALSE
 #' @param comment comment
 #' @export
-omega_param <- function(value, link, fix = FALSE, comment = NULL) {
+omega_param <- function(value, link, fixed = FALSE, comment = NULL) {
   # note omega param takes param and value singular, vs the block
   output <- list(block = FALSE,
        link = link,
-       fix = fix,
+       fixed = fixed,
        correlation = FALSE,
        value = value,
        comment = comment)
@@ -56,17 +56,17 @@ omega_param <- function(value, link, fix = FALSE, comment = NULL) {
 #' diagonal values
 #' @param value value
 #' @param name name
-#' @param fix whether fixed DEFAULT: FALSE
+#' @param fixed whether fixed DEFAULT: FALSE
 #' @param comment comment
 #' @details
 #' PROP, ADD are specially recognized names to design the residual
 #' error structure, else, will need to code it oneself
 #' @export
-sigma_param <- function(value, name, fix = FALSE, comment = NULL) {
+sigma_param <- function(value, name, fixed = FALSE, comment = NULL) {
   # note omega param takes param and value singular, vs the block
   output <- list(block = FALSE,
               name = name,
-              fix = fix,
+              fixed = fixed,
               correlation = FALSE,
               value = value,
               comment = comment)

--- a/R/blueprint.R
+++ b/R/blueprint.R
@@ -158,7 +158,7 @@ Blueprint <-
             # if numeric assume shorthand value only
             # CL = 4.5
             if (is_bare_numeric(omega_info)) {
-              return(omega_param(omega_info, .pn, fix = FALSE))
+              return(omega_param(omega_info, .pn, fixed = FALSE))
             }
             # for now going to make the big assumption people will
             # actually use block()/omega_param to create full omegas specifications,

--- a/inst/templates/nonmem/partials/omega.txt
+++ b/inst/templates/nonmem/partials/omega.txt
@@ -5,5 +5,5 @@ $OMEGA BLOCK({{num_params}})
 {{^block}}
 $OMEGA
 
-{{value}}
+{{value}} {{#fixed}} FIX {{/fixed}}
 {{/block}}

--- a/man/block.Rd
+++ b/man/block.Rd
@@ -4,14 +4,15 @@
 \alias{block}
 \title{block matrix}
 \usage{
-block(..., param_names, fix = FALSE, correlation = FALSE, comment = NULL)
+block(..., param_names, fixed = FALSE, correlation = FALSE,
+  comment = NULL)
 }
 \arguments{
 \item{...}{elements to coerce into a block matrix}
 
 \item{param_names}{parameters associated with the elements of the matrix}
 
-\item{fix}{whether the values should be fixed}
+\item{fixed}{whether the values should be fixed}
 
 \item{correlation}{whether to create as a correlation matrix}
 

--- a/man/omega_param.Rd
+++ b/man/omega_param.Rd
@@ -4,14 +4,14 @@
 \alias{omega_param}
 \title{diagonal values}
 \usage{
-omega_param(value, link, fix = FALSE, comment = NULL)
+omega_param(value, link, fixed = FALSE, comment = NULL)
 }
 \arguments{
 \item{value}{value}
 
 \item{link}{link parameter name}
 
-\item{fix}{whether fixed DEFAULT: FALSE}
+\item{fixed}{whether fixed DEFAULT: FALSE}
 
 \item{comment}{comment}
 }

--- a/man/sigma_param.Rd
+++ b/man/sigma_param.Rd
@@ -4,14 +4,14 @@
 \alias{sigma_param}
 \title{diagonal values}
 \usage{
-sigma_param(value, name, fix = FALSE, comment = NULL)
+sigma_param(value, name, fixed = FALSE, comment = NULL)
 }
 \arguments{
 \item{value}{value}
 
 \item{name}{name}
 
-\item{fix}{whether fixed DEFAULT: FALSE}
+\item{fixed}{whether fixed DEFAULT: FALSE}
 
 \item{comment}{comment}
 }

--- a/tests/testthat/test-block.R
+++ b/tests/testthat/test-block.R
@@ -3,12 +3,12 @@ context("block")
 describe("block() works", {
   it("can be initialized correctly", {
     input <- block(0.4, 0.6, 0.09, param_names = c("CL", "V"), correlation = TRUE)
-    output <- structure(list(block = TRUE, params = c("CL", "V"), fix = FALSE,
+    output <- structure(list(block = TRUE, params = c("CL", "V"), fixed = FALSE,
                      correlation = TRUE, matrix = structure(c(0.4, 0.113841995766062,
                                                               0.113841995766062, 0.09), .Dim = c(2L, 2L)),
                      value = "\n4.000000e-01 \n1.138420e-01 9.000000e-02",
                      num_params = 2L, comment = NULL), .Names = c("block", "params",
-                                                                  "fix", "correlation",
+                                                                  "fixed", "correlation",
                                                                   "matrix", "value", "num_params", "comment"
                      ), class = c("block"))
     expect_equal(input, output)

--- a/tests/testthat/test-omega_param.R
+++ b/tests/testthat/test-omega_param.R
@@ -8,13 +8,13 @@ describe("omega_param() works", {
         list(
           block = FALSE,
           link = "CL",
-          fix = FALSE,
+          fixed = FALSE,
           correlation = FALSE,
           value = 0.04,
           comment = NULL
         ),
         .Names = c("block", "link",
-                   "fix", "correlation", "value", "comment"),
+                   "fixed", "correlation", "value", "comment"),
         class = "omega"
       )
     expect_equal(input,

--- a/tests/testthat/test-partials-nonmem-omega.R
+++ b/tests/testthat/test-partials-nonmem-omega.R
@@ -1,0 +1,31 @@
+context("test-partials-nonmem-omega.R")
+
+
+describe("nonmem omega partials work", {
+  blueprint <- Blueprint$new("nonmem")
+  blueprint$template <- "
+{{#omegas}}
+{{> omega}}
+{{/omegas}}
+"
+  it("renders hierarchies properly", {
+  blueprint$add_hierarchies(b1 = block(0.4, 0.6, 0.09, param_names = c("CL", "V"), correlation = TRUE))
+  expect_equal(blueprint$render(), "\n$OMEGA BLOCK(2)\n4.000000e-01 \n1.138420e-01 9.000000e-02\n\n")
+
+  blueprint$add_hierarchies(b1 = NULL)
+  blueprint$add_hierarchies(b1 = block(0.1, 0.6, 0.09, param_names = c("CL", "V"), correlation = TRUE, fixed = TRUE))
+  expect_equal(blueprint$render(), "\n$OMEGA BLOCK(2)\n1.000000e-01 FIXED \n5.692100e-02 9.000000e-02\n\n")
+
+  blueprint$add_hierarchies(b1 = NULL)
+  })
+  it("renders diagnoals properly", {
+    blueprint$add_hierarchies(CL = omega_param(0.4, link = "CL"))
+    expect_equal(blueprint$render(), "\n$OMEGA\n0.4 \n\n")
+    blueprint$add_hierarchies(CL = NULL)
+    blueprint$add_hierarchies(CL = omega_param(0.4, link = "CL", fixed = TRUE))
+    expect_equal(blueprint$render(), "\n$OMEGA\n0.4  FIX \n\n")
+    blueprint$add_hierarchies(V = omega_param(0.4, link = "V"),
+                              KA = omega_param(0.1, link = "KA", fixed = TRUE))
+    expect_equal(blueprint$render(), "\n$OMEGA\n0.4  FIX \n$OMEGA\n0.4 \n$OMEGA\n0.1  FIX \n\n")
+  })
+})

--- a/tests/testthat/test-sigma_param.R
+++ b/tests/testthat/test-sigma_param.R
@@ -8,12 +8,12 @@ describe("sigma_param() works", {
         list(
           block = FALSE,
           name = "PROP",
-          fix = FALSE,
+          fixed = FALSE,
           correlation = FALSE,
           value = 0.04,
           comment = NULL
         ),
-        .Names = c("block", "name", "fix",
+        .Names = c("block", "name", "fixed",
                    "correlation", "value", "comment"),
         class = "sigma"
       )


### PR DESCRIPTION
update omega and sigma params to be consistent with parameter() in being called FIXED

in partials for nonmem, omega_param should reflect fix for diagonal elements